### PR TITLE
Can be applied validation

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -5,4 +5,13 @@ class BulkDiscount < ApplicationRecord
   validates_presence_of :threshold, :discount
   validates_numericality_of :discount, only_integer: true, greater_than: 0, less_than: 100
   validates_numericality_of :threshold, only_integer: true, greater_than: 0
+  validate :can_be_applied, if: Proc.new { |d| d.discount.present? && d.threshold.present? }
+
+  def can_be_applied
+    return unless BulkDiscount.any? 
+    highest_discount = BulkDiscount.order(discount: :desc).first 
+    if discount < highest_discount.discount && threshold > highest_discount.threshold
+      errors.add(:discount, "is less than the current highest discount, but with a greater threshold, and will never be applied")
+    end
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -3,6 +3,7 @@ class InvoiceItem < ApplicationRecord
   belongs_to :item
   belongs_to :bulk_discount, optional: true 
   enum status: ["packaged", "pending", "shipped"]
+  after_find :add_discount
   after_create :add_discount
 
   def item_name

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -14,7 +14,7 @@ class InvoiceItem < ApplicationRecord
   end
 
   def find_discount
-    item.merchant.bulk_discounts.where("#{quantity} >= bulk_discounts.threshold").order(threshold: :desc).first
+    item.merchant.bulk_discounts.where("#{quantity} >= bulk_discounts.threshold").order(discount: :desc).first
   end
 
   def add_discount 

--- a/spec/features/merchants/bulk_discounts/new_spec.rb
+++ b/spec/features/merchants/bulk_discounts/new_spec.rb
@@ -99,7 +99,6 @@ RSpec.describe "New Merchant Bulk Discount page" do
       end
 
       it "doesn't let me create a discount that will never be applied" do 
-        # discount_3 = @merchant.bulk_discounts.create!(discount: 15, threshold: 15)
         visit new_merchant_bulk_discount_path(@merchant)
 
         fill_in(:discount, with: 15)
@@ -112,7 +111,5 @@ RSpec.describe "New Merchant Bulk Discount page" do
         end
       end
     end
-  end
-
-       
+  end     
 end

--- a/spec/features/merchants/bulk_discounts/new_spec.rb
+++ b/spec/features/merchants/bulk_discounts/new_spec.rb
@@ -97,6 +97,20 @@ RSpec.describe "New Merchant Bulk Discount page" do
           expect(page).to have_content("Error: Threshold must be greater than 0")
         end
       end
+
+      it "doesn't let me create a discount that will never be applied" do 
+        # discount_3 = @merchant.bulk_discounts.create!(discount: 15, threshold: 15)
+        visit new_merchant_bulk_discount_path(@merchant)
+
+        fill_in(:discount, with: 15)
+        fill_in(:threshold, with: 15)
+        click_on("Submit")
+
+        expect(current_path).to eq(new_merchant_bulk_discount_path(@merchant))
+        within "#flash-messages" do
+          expect(page).to have_content("Error: Discount is less than the current highest discount, but with a greater threshold, and will never be applied")
+        end
+      end
     end
   end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -110,25 +110,10 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
-    describe "#discount_cost" do 
-      it "returns the cost that is subtracted from the total revenue for a particular merchant" do 
-        expect(@invoice.total_revenue(@merchant)).to eq(150)
-        expect(@invoice.discount_cost(@merchant)).to eq(21)
-      end
-    end
-
     describe '#discounted_revenue' do 
       it 'returns the total discounted revenue for specific invoice and merchant' do 
         expect(@invoice.total_revenue(@merchant)).to eq(150)
-        expect(@invoice.discount_cost(@merchant)).to eq(21)
         expect(@invoice.discounted_revenue(@merchant)).to eq(129)
-      end
-    end
-
-    describe "#admin_discount_cost" do 
-      it "returns the cost that is subtracted from the total revenue for the whole invoice" do 
-        expect(@invoice.admin_total_revenue).to eq(250)
-        expect(@invoice.admin_discount_cost).to eq(41)
       end
     end
 


### PR DESCRIPTION
Completes extension about validating whether the discount can be used or not. Additionally cleans up the discounted_revenue methods to do it a single query (using coalesce!)